### PR TITLE
Fix issue #2578

### DIFF
--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -216,7 +216,6 @@ fn line_break(
                     rect: rect_from_x_range(first_row_indentation..=first_row_indentation),
                     ends_with_newline: false,
                 });
-                row_start_x += first_row_indentation;
                 first_row_indentation = 0.0;
             } else if let Some(last_kept_index) = row_break_candidates.get(job.wrap.break_anywhere)
             {

--- a/examples/wrapping-layout/Cargo.toml
+++ b/examples/wrapping-layout/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wrapping-layout"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eframe = { path = "../../crates/eframe", features = [
+    "__screenshot", # __screenshot is so we can dump a screenshot using EFRAME_SCREENSHOT_TO
+] }
+tracing-subscriber = "0.3"

--- a/examples/wrapping-layout/src/main.rs
+++ b/examples/wrapping-layout/src/main.rs
@@ -1,0 +1,35 @@
+use eframe::{
+    egui::{self, TextFormat},
+    epaint::text::LayoutJob,
+};
+
+fn main() -> Result<(), eframe::Error> {
+    let native_options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "My egui App",
+        native_options,
+        Box::new(|cc| Box::new(MyEguiApp::new(cc))),
+    )
+}
+
+#[derive(Default)]
+struct MyEguiApp {}
+
+impl MyEguiApp {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self::default()
+    }
+}
+
+impl eframe::App for MyEguiApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+           ui.horizontal_wrapped(|ui| {
+                ui.hyperlink_to("@npub1vdaeclr2mnntmyw...", "whocares");
+                let text = " lnbc10u1p3lz4dppp5dsj2mh5kgqfqqxwhkrkw60stn8aph4gm2h2053xvwvvlvjm3q9eqdpqxycrqvpqd3hhgar9wfujqarfvd4k2arncqzpgxqzz6sp5vfenc5l4uafsky0w069zs329edf608ggpjjveguwxfl3xlswg5vq9qyyssqj46d5x3gsnljffm79eqwszk4mk47lkxywdp8mxum7un3qm0ztwj9jf46cm4lw2un9hk4gttgtjdrk29h27xu4e3ume20sqsna8q7xwspqqkwq7";
+                let job = LayoutJob::single_section(text.to_owned(), TextFormat::default());
+                ui.label(job);
+           });
+       });
+    }
+}


### PR DESCRIPTION
- `row_start_x` tracks a virtual position in the source paragraph (the one that is too long) for which length has already been processed. When creating an empty row, this position should not be updated as no glyphs were consumed from the source paragraph.
- added example that would demonstrate the problem if the line was included, and that is fixed with this commit