### PR TITLE
Fix cursor not advancing when first label contains a '\n'

### DIFF
--- a/crates/egui/src/widgets/label.rs
+++ b/crates/egui/src/widgets/label.rs
@@ -127,6 +127,16 @@ impl Label {
                 !text_galley.galley.rows.is_empty(),
                 "Galleys are never empty"
             );
+
+            // set the row height to ensure the cursor advancement is correct. when creating a child ui such as with
+            // ui.horizontal_wrapped, the initial cursor will be set to the height of the child ui. this can lead
+            // to the cursor not advancing to the second row but rather expanding the height of the cursor.
+            //
+            // note that we do not set the row height earlier in this function as we do want to allow populating
+            // `first_row_min_height` above. however it is crucial the placer knows the actual row height by
+            // setting the cursor height before ui.allocate_rect() gets called.
+            ui.set_row_height(text_galley.galley.rows[0].height());
+
             // collect a response from many rows:
             let rect = text_galley.galley.rows[0]
                 .rect


### PR DESCRIPTION
Fixes https://github.com/mikedilger/gossip/issues/336 and https://github.com/mikedilger/gossip/issues/347 by ensuring ui.placer.region.cursor is set to the correct line height.