### PR TITLE
Export CollapsingState (it has all the documentation to be user-facing)

### DIFF
--- a/crates/egui/src/containers/mod.rs
+++ b/crates/egui/src/containers/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod window;
 
 pub use {
     area::Area,
-    collapsing_header::{CollapsingHeader, CollapsingResponse},
+    collapsing_header::{CollapsingHeader, CollapsingResponse, CollapsingState},
     combo_box::*,
     frame::Frame,
     panel::{CentralPanel, SidePanel, TopBottomPanel},


### PR DESCRIPTION
CollapsingState is documented as if it was meant to be user facing, but was not exported. Used on "side-menu".