### PR TITLE
Feature: Change textedit margin property to margin struct

### DIFF
--- a/crates/egui/src/widgets/drag_value.rs
+++ b/crates/egui/src/widgets/drag_value.rs
@@ -484,7 +484,10 @@ impl<'a> Widget for DragValue<'a> {
                     .clip_text(false)
                     .horizontal_align(ui.layout().horizontal_align())
                     .vertical_align(ui.layout().vertical_align())
-                    .margin(ui.spacing().button_padding)
+                    .margin(Margin::symmetric(
+                        ui.spacing().button_padding.x,
+                        ui.spacing().button_padding.y,
+                    ))
                     .min_size(ui.spacing().interact_size)
                     .id(id)
                     .desired_width(ui.spacing().interact_size.x)

--- a/crates/egui/src/widgets/text_edit/builder.rs
+++ b/crates/egui/src/widgets/text_edit/builder.rs
@@ -60,7 +60,7 @@ pub struct TextEdit<'t> {
     layouter: Option<&'t mut dyn FnMut(&Ui, &str, f32) -> Arc<Galley>>,
     password: bool,
     frame: bool,
-    margin: Vec2,
+    margin: Margin,
     multiline: bool,
     interactive: bool,
     desired_width: Option<f32>,
@@ -110,7 +110,7 @@ impl<'t> TextEdit<'t> {
             layouter: None,
             password: false,
             frame: true,
-            margin: vec2(4.0, 2.0),
+            margin: Margin::symmetric(4.0, 2.0),
             multiline: true,
             interactive: true,
             desired_width: None,
@@ -245,7 +245,7 @@ impl<'t> TextEdit<'t> {
     }
 
     /// Set margin of text. Default is [4.0,2.0]
-    pub fn margin(mut self, margin: Vec2) -> Self {
+    pub fn margin(mut self, margin: Margin) -> Self {
         self.margin = margin;
         self
     }
@@ -354,13 +354,20 @@ impl<'t> TextEdit<'t> {
         let where_to_put_background = ui.painter().add(Shape::Noop);
 
         let margin = self.margin;
-        let max_rect = ui.available_rect_before_wrap().shrink2(margin);
+        let available = ui.available_rect_before_wrap();
+        let max_rect = Rect::from_x_y_ranges(
+            available.left() + margin.left..=available.right() - margin.right,
+            available.top() + margin.top..=available.bottom() - margin.bottom,
+        );
         let mut content_ui = ui.child_ui(max_rect, *ui.layout());
 
         let mut output = self.show_content(&mut content_ui);
 
         let id = output.response.id;
-        let frame_rect = output.response.rect.expand2(margin);
+        let frame_rect = Rect::from_x_y_ranges(
+            output.response.rect.left() - margin.left..=output.response.rect.right() + margin.right,
+            output.response.rect.top() - margin.top..=output.response.rect.bottom() + margin.bottom,
+        );
         ui.allocate_space(frame_rect.size());
         if interactive {
             output.response |= ui.interact(frame_rect, id, Sense::click());
@@ -443,7 +450,7 @@ impl<'t> TextEdit<'t> {
             available_width
         } else {
             desired_width.min(available_width)
-        } - margin.x * 2.0;
+        } - (margin.left + margin.right);
 
         let font_id_clone = font_id.clone();
         let mut default_layouter = move |ui: &Ui, text: &str, wrap_width: f32| {
@@ -466,8 +473,12 @@ impl<'t> TextEdit<'t> {
             galley.size().x.max(wrap_width)
         };
         let desired_height = (desired_height_rows.at_least(1) as f32) * row_height;
-        let desired_size = vec2(desired_width, galley.size().y.max(desired_height))
-            .at_least(min_size - margin * 2.0);
+        let at_least = Vec2::new(
+            min_size.x - (margin.left + margin.right),
+            min_size.y - (margin.top + margin.bottom),
+        );
+        let desired_size =
+            vec2(desired_width, galley.size().y.max(desired_height)).at_least(at_least);
 
         let (auto_id, rect) = ui.allocate_space(desired_size);
 

--- a/crates/epaint/src/text/text_layout.rs
+++ b/crates/epaint/src/text/text_layout.rs
@@ -290,7 +290,7 @@ fn line_break(paragraph: &Paragraph, job: &LayoutJob, out_rows: &mut Vec<Row>, e
 
                 // (bu5hm4nn) first row indentation gets consumed the first time it's used
                 if first_row_indentation > 0.0 {
-                    first_row_indentation = 0.0
+                    first_row_indentation = 0.0;
                 }
             } else {
                 // Found no place to break, so we have to overrun wrap_width.


### PR DESCRIPTION
It was using `Vec2` despite their being a `Margin` struct which allows asymmetric margins, which we need to add space for icons before the text. 